### PR TITLE
python3-vcstool not showing up

### DIFF
--- a/docker/ubuntu-2204/Dockerfile
+++ b/docker/ubuntu-2204/Dockerfile
@@ -54,7 +54,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt install -y \
     libcairomm-1.0-dev \
     libyaml-cpp-dev \
     pybind11-dev \
-    python3-vcstool \
     libgtest-dev
 
 RUN touch /usr/lib/python3/dist-packages/_Pltk_init.so


### PR DESCRIPTION
`python3-vcstool` fails to apt install. I don't think we really need this inside docker, so removing. 